### PR TITLE
Fix for hitsplat api change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.17'
+def runeLiteVersion = '1.8.30'
 
 dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'hsj.external.theatreofbloodstats'
-version = '1.3'
+version = '1.3.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/hsj/external/theatreofbloodstats/TheatreOfBloodStatsPlugin.java
+++ b/src/main/java/hsj/external/theatreofbloodstats/TheatreOfBloodStatsPlugin.java
@@ -44,6 +44,7 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Hitsplat;
+import net.runelite.api.HitsplatID;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullNpcID;
@@ -1072,7 +1073,7 @@ public class TheatreOfBloodStatsPlugin extends Plugin
 			totalDmg += hitsplat.getAmount();
 			totalDamage.put(npcName, totalDmg);
 		}
-		else if (hitsplat.getHitsplatType() == Hitsplat.HitsplatType.HEAL)
+		else if (hitsplat.getHitsplatType() == HitsplatID.HEAL)
 		{
 			int healed = totalHealing.getOrDefault(npcName, 0);
 			healed += hitsplat.getAmount();


### PR DESCRIPTION
Runelite adjusted the way that they communicate hitsplat types through their API, which was a breaking change for several plugins. This change addresses that issue.

Tested and verified that this change fixes the plugin locally.